### PR TITLE
Add ability to set a custom copy to clipboard button on Options page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "jira-software-tool",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@craco/craco": "^6.0.0",
+        "@heroicons/react": "^1.0.3",
+        "@tailwindcss/forms": "^0.3.3",
         "@tailwindcss/postcss7-compat": "^2.0.2",
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.3",
@@ -1352,6 +1354,14 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "node_modules/@heroicons/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-wdzWbDiFKzeL6xFJsgY2PqvDkx4hFmQDpEFRVj872EA71XOjr8g0DQj5rHWm0y7LwfGOFL0eQmEiMbTyGNOnTQ==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2333,6 +2343,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.3.tgz",
+      "integrity": "sha512-U8Fi/gq4mSuaLyLtFISwuDYzPB73YzgozjxOIHsK6NXgg/IWD1FLaHbFlWmurAMyy98O+ao74ksdQefsquBV1Q==",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0"
       }
     },
     "node_modules/@tailwindcss/postcss7-compat": {
@@ -12199,6 +12220,14 @@
         "node": ">= 4"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz",
+      "integrity": "sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -21867,6 +21896,12 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@heroicons/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-wdzWbDiFKzeL6xFJsgY2PqvDkx4hFmQDpEFRVj872EA71XOjr8g0DQj5rHWm0y7LwfGOFL0eQmEiMbTyGNOnTQ==",
+      "requires": {}
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -22642,6 +22677,14 @@
         "@svgr/plugin-jsx": "^5.4.0",
         "@svgr/plugin-svgo": "^5.4.0",
         "loader-utils": "^2.0.0"
+      }
+    },
+    "@tailwindcss/forms": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.3.tgz",
+      "integrity": "sha512-U8Fi/gq4mSuaLyLtFISwuDYzPB73YzgozjxOIHsK6NXgg/IWD1FLaHbFlWmurAMyy98O+ao74ksdQefsquBV1Q==",
+      "requires": {
+        "mini-svg-data-uri": "^1.2.3"
       }
     },
     "@tailwindcss/postcss7-compat": {
@@ -30820,6 +30863,11 @@
           }
         }
       }
+    },
+    "mini-svg-data-uri": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz",
+      "integrity": "sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.0.0",
+    "@heroicons/react": "^1.0.3",
+    "@tailwindcss/forms": "^0.3.3",
     "@tailwindcss/postcss7-compat": "^2.0.2",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,8 @@
     "activeTab",
     "tabs",
     "declarativeContent",
-    "scripting"
+    "scripting",
+    "storage"
   ],
   "action": {
     "default_popup": "index.html?page=Popup",

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,38 @@
+const Alert = ({
+  message,
+  type,
+  display,
+}: {
+  message?: string;
+  type?: string;
+  display?: string;
+}) => {
+  let textClass = 'text-gray-900';
+  const displayClass = display === 'inline' ? 'inline' : 'block';
+
+  switch (type) {
+    case 'success':
+      textClass = 'text-green-500';
+      break;
+    case 'error':
+      textClass = 'text-red-500';
+      break;
+    case 'warning':
+      textClass = 'text-yellow-500';
+      break;
+    case 'info':
+      textClass = 'text-blue-500';
+      break;
+    case 'muted':
+      textClass = 'text-gray-400';
+      break;
+  }
+
+  return (
+    <div className={`align-middle ${displayClass} ${textClass}`}>
+      <span className="align-middle">{message}</span>
+    </div>
+  );
+};
+
+export default Alert;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  block?: boolean;
+}
+
+const Button = (props: ButtonProps) => {
+  const { children, className, block, disabled, ...rest } = props;
+
+  return (
+    <button
+      {...rest}
+      className={`py-2 px-4 text-sm text-center rounded-md bg-gray-300 dark:bg-gray-700 dark:text-gray-300 truncate ${
+        disabled
+          ? 'disabled:opacity-50 cursor-not-allowed'
+          : 'hover:bg-gray-200 focus:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-gray-600 dark:hover:text-white'
+      } ${block ? 'block w-full' : ''} ${className ?? ''}`}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton.tsx
@@ -1,19 +1,19 @@
-import React from "react";
+import React from 'react';
+
+import { ClipboardIcon, CheckIcon } from '@heroicons/react/outline';
+
+import Button from '../components/Button';
 
 const CopyToClipboardButton = ({
   value,
-  disabled,
   icon,
   initialText,
   endCopyText,
-  className,
 }: {
   value: string;
   initialText: string;
   endCopyText: string;
-  disabled?: boolean;
   icon?: string;
-  className?: string;
 }) => {
   const [copied, setCopied] = React.useState(false);
 
@@ -25,50 +25,19 @@ const CopyToClipboardButton = ({
   }, [copied]);
 
   return (
-    <button
-      type="button"
-      className={`py-2 px-4 text-sm text-center rounded-md bg-gray-300 dark:bg-gray-700 dark:text-gray-300 ${
-        disabled
-          ? "disabled:opacity-50 cursor-not-allowed"
-          : "hover:bg-gray-200 focus:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-gray-600 dark:hover:text-white"
-      } ${className}`}
+    <Button
       onClick={() => {
         navigator.clipboard.writeText(value);
         setCopied(true);
       }}
-      disabled={disabled}
+      block={true}
+      disabled={!value}
     >
       {!icon ? (
         copied ? (
-          <svg
-            className="w-4 h-4 inline-block mr-1 text-green-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M5 13l4 4L19 7"
-            />
-          </svg>
+          <CheckIcon className="w-4 h-4 inline-block mr-1 text-green-500" />
         ) : (
-          <svg
-            className="w-4 h-4 inline-block mr-1"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-            />
-          </svg>
+          <ClipboardIcon className="w-4 h-4 inline-block mr-1" />
         )
       ) : (
         icon
@@ -76,7 +45,7 @@ const CopyToClipboardButton = ({
       <span className="align-middle text-sm">
         {copied ? endCopyText : initialText}
       </span>
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/FormGroup.tsx
+++ b/src/components/FormGroup.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FormGroup = ({ children }: { children: React.ReactNode }) => {
+  return <div className="mb-8">{children}</div>;
+};
+
+export default FormGroup;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -19,7 +19,7 @@ const Modal = ({
           className="bg-black bg-opacity-80 fixed inset-0 h-screen w-screen z-10 py-32 px-4 overflow-y-auto text-base"
           onClick={onClickHandler}
         >
-          <div className="mx-auto max-w-lg px-4 py-4 bg-white rounded-lg dark:bg-gray-900 dark:text-gray-400">
+          <div className="mx-auto max-w-lg px-4 py-4 bg-white rounded-lg dark:bg-gray-800 dark:text-gray-400">
             {children}
           </div>
         </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const Modal = ({
+  children,
+  show,
+  onClose,
+}: {
+  children?: React.ReactNode;
+  show?: boolean;
+  onClose?: (event: React.MouseEvent<any>) => void;
+}) => {
+  const onClickHandler = (event: React.MouseEvent<any>) =>
+    event.target === event.currentTarget && onClose && onClose(event);
+
+  return (
+    <>
+      {show && (
+        <div
+          className="bg-black bg-opacity-80 fixed inset-0 h-screen w-screen z-10 py-32 px-4 overflow-y-auto text-base"
+          onClick={onClickHandler}
+        >
+          <div className="mx-auto max-w-lg px-4 py-4 bg-white rounded-lg dark:bg-gray-900 dark:text-gray-400">
+            {children}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default Modal;

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const TextArea = (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => {
+  const { value } = props;
+  const textareaElement = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    updateTextareaHeight();
+  }, [value]);
+
+  const updateTextareaHeight = () => {
+    if (textareaElement.current) {
+      const $element = textareaElement.current;
+      const extraHeight = 3;
+
+      $element.style.height = `auto`;
+      $element.style.height = `${$element.scrollHeight + extraHeight}px`;
+      $element.style.resize = `none`;
+      $element.style.overflowY = `hidden`;
+    }
+  };
+
+  return <textarea ref={textareaElement} {...props}></textarea>;
+};
+
+export default TextArea;

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -145,7 +145,7 @@ const Options = ({ manifest }: any) => {
       <Modal show={modalIsOpen} onClose={() => setModalIsOpen(false)}>
         <div className="flex items-center mb-4">
           <div className="flex-grow">
-            <InformationCircleIcon className="w-5 h-5 inline-block mr-1" />
+            <InformationCircleIcon className="w-5 h-5 text-gray-900 dark:text-gray-300 inline-block mr-1" />
             <span className="align-middle font-medium">
               Custom copy to clipboard button
             </span>
@@ -231,7 +231,7 @@ const Options = ({ manifest }: any) => {
                       }}
                       aria-label="Open Button Label modal"
                     >
-                      <InformationCircleIcon className="w-5 h-5" />
+                      <InformationCircleIcon className="w-5 h-5 text-gray-900 dark:text-gray-300" />
                     </button>
                   </div>
                 </div>
@@ -287,7 +287,7 @@ const Options = ({ manifest }: any) => {
                       }}
                       aria-label="Open Custom value modal"
                     >
-                      <InformationCircleIcon className="w-5 h-5" />
+                      <InformationCircleIcon className="w-5 h-5 text-gray-900 dark:text-gray-300" />
                     </button>
                   </div>
                 </div>

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Helmet } from 'react-helmet';
+import { InformationCircleIcon, XIcon } from '@heroicons/react/solid';
 
 import {
   CLIPBOARD_ITEMS_STORAGE_KEY,
@@ -15,6 +16,7 @@ import FormGroup from '../components/FormGroup';
 import Button from '../components/Button';
 import TextArea from '../components/TextArea';
 import Alert from '../components/Alert';
+import Modal from '../components/Modal';
 
 const alertTimeoutMs = 3000;
 let alertTimeoutID = setTimeout(() => {}, 0);
@@ -36,6 +38,15 @@ const Options = ({ manifest }: any) => {
     type: 'error',
     message: 'Something went wrong. Please try again.',
   });
+
+  const [modalIsOpen, setModalIsOpen] = React.useState(false);
+  const [modalContent, setModalContent] = React.useState<React.ReactNode>();
+
+  const openModal = (content?: React.ReactNode) => {
+    setModalContent(content);
+    setModalIsOpen(true);
+  };
+  const closeModal = () => setModalIsOpen(false);
 
   const hideAlert = () => {
     const { show, ...rest } = alert;
@@ -118,11 +129,35 @@ const Options = ({ manifest }: any) => {
     setInputValueRemaining(CLIPBOARD_ITEM_VALUE_MAX_LENGTH - inputValue.length);
   }, [inputValue]);
 
+  React.useEffect(() => {
+    document.body.style.overflowY = modalIsOpen ? 'hidden' : 'auto';
+
+    if (!modalIsOpen) {
+      setModalContent(null);
+    }
+  }, [modalIsOpen]);
+
   return (
     <>
       <Helmet>
         <title>{`${manifest?.name} | Options`}</title>
       </Helmet>
+      <Modal show={modalIsOpen} onClose={() => setModalIsOpen(false)}>
+        <div className="flex items-center mb-4">
+          <div className="flex-grow">
+            <InformationCircleIcon className="w-5 h-5 inline-block mr-1" />
+            <span className="align-middle font-medium">
+              Custom copy to clipboard button
+            </span>
+          </div>
+          <div className="flex-none">
+            <button type="button" onClick={closeModal} aria-label="Close">
+              <XIcon className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+        <div className="mb-4">{modalContent}</div>
+      </Modal>
       <section className="py-6 dark:bg-gray-900 dark:text-gray-300 min-h-screen text-base">
         <div className="md:container md:mx-auto px-4">
           <div className="mb-4 border rounded-md px-4 pt-8 pb-10 bg-white dark:bg-gray-800 dark:border-gray-700">
@@ -175,16 +210,31 @@ const Options = ({ manifest }: any) => {
                 </div>
               </FormGroup>
               <FormGroup>
-                <label className="block mb-1" htmlFor="copyToClipboardItem">
-                  Button label
-                </label>
-                <label className="block mb-1" htmlFor="copyToClipboardItem">
-                  <small>
-                    Set a custom copy to clipboard button on the dropdown menu.
-                    This button can be hidden on the dropdown by setting the
-                    label empty.
-                  </small>
-                </label>
+                <div className="flex mb-1">
+                  <div className="flex-grow">
+                    <label className="block" htmlFor="copyToClipboardItem">
+                      Button label
+                    </label>
+                  </div>
+                  <div className="flex-none">
+                    <button
+                      type="button"
+                      className="px-1"
+                      onClick={() => {
+                        openModal(
+                          <p>
+                            Set a custom copy to clipboard button on the
+                            dropdown menu. This button can be hidden on the
+                            dropdown by setting the label empty.
+                          </p>
+                        );
+                      }}
+                      aria-label="Open Button Label modal"
+                    >
+                      <InformationCircleIcon className="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
                 <input
                   type="text"
                   id="copyToClipboardItem"
@@ -196,32 +246,51 @@ const Options = ({ manifest }: any) => {
                 />
               </FormGroup>
               <FormGroup>
-                <label
-                  htmlFor="copyToClipboardItemFormat"
-                  className="block mb-1"
-                >
-                  Custom value
-                </label>
-                <label
-                  htmlFor="copyToClipboardItemFormat"
-                  className="block mb-1"
-                >
-                  <small>
-                    Available variables that can be used for custom value:{' '}
-                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
-                      [id]
-                    </span>
-                    ,{' '}
-                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
-                      [title]
-                    </span>
-                    ,{' '}
-                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
-                      [url]
-                    </span>
-                    .
-                  </small>
-                </label>
+                <div className="flex mb-1">
+                  <div className="flex-grow">
+                    <label
+                      className="block"
+                      htmlFor="copyToClipboardItemFormat"
+                    >
+                      Custom value
+                    </label>
+                  </div>
+                  <div className="flex-none">
+                    <button
+                      type="button"
+                      className="px-1"
+                      onClick={() => {
+                        openModal(
+                          <>
+                            <p className="mb-2">
+                              Available variables that can be used for custom
+                              value:{' '}
+                              <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                                [id]
+                              </span>
+                              ,{' '}
+                              <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                                [title]
+                              </span>
+                              ,{' '}
+                              <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                                [url]
+                              </span>
+                              .
+                            </p>
+                            <p>
+                              The custom value can have new lines and up to 100
+                              characters.
+                            </p>
+                          </>
+                        );
+                      }}
+                      aria-label="Open Custom value modal"
+                    >
+                      <InformationCircleIcon className="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
                 <TextArea
                   name="copyToClipboardItemFormat"
                   id="copyToClipboardItemFormat"
@@ -241,7 +310,7 @@ const Options = ({ manifest }: any) => {
                 </p>
               </FormGroup>
               <FormGroup>
-                <Button className="mr-4" disabled={submitting}>
+                <Button type="submit" className="mr-4" disabled={submitting}>
                   {submitting ? 'Saving...' : 'Save'}
                 </Button>
                 {alert.show && (

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import { Helmet } from 'react-helmet';
 
-import { CLIPBOARD_ITEMS_STORAGE_KEY } from '../utils/Constants';
+import {
+  CLIPBOARD_ITEMS_STORAGE_KEY,
+  CLIPBOARD_ITEM_VALUE_MAX_LENGTH,
+  DEFAULT_CLIPBOARD_ITEM,
+} from '../utils/Constants';
 import { chromeStorageGet, chromeStorageSet } from '../utils/ChromeStorage';
 
 import { ThemeContext } from '../providers/ThemeProvider';
@@ -23,6 +27,9 @@ const Options = ({ manifest }: any) => {
   const [inputTheme, setInputTheme] = React.useState(theme);
 
   const [submitting, setSubmitting] = React.useState(false);
+  const [inputValueRemaining, setInputValueRemaining] = React.useState(
+    CLIPBOARD_ITEM_VALUE_MAX_LENGTH
+  );
 
   const [alert, setAlert] = React.useState({
     show: false,
@@ -38,12 +45,7 @@ const Options = ({ manifest }: any) => {
   const retrieveClipboardItems = async () => {
     const clipboardItems: any = await chromeStorageGet(
       CLIPBOARD_ITEMS_STORAGE_KEY,
-      [
-        {
-          label: 'ID - Title',
-          value: '[id] - [title]',
-        },
-      ]
+      [DEFAULT_CLIPBOARD_ITEM]
     );
 
     const [firstItem] = clipboardItems;
@@ -112,6 +114,10 @@ const Options = ({ manifest }: any) => {
     retrieveClipboardItems();
   }, []);
 
+  React.useEffect(() => {
+    setInputValueRemaining(CLIPBOARD_ITEM_VALUE_MAX_LENGTH - inputValue.length);
+  }, [inputValue]);
+
   return (
     <>
       <Helmet>
@@ -175,6 +181,8 @@ const Options = ({ manifest }: any) => {
                 <label className="block mb-1" htmlFor="copyToClipboardItem">
                   <small>
                     Set a custom copy to clipboard button on the dropdown menu.
+                    This button can be hidden on the dropdown by setting the
+                    label empty.
                   </small>
                 </label>
                 <input
@@ -200,15 +208,15 @@ const Options = ({ manifest }: any) => {
                 >
                   <small>
                     Available variables that can be used for custom value:{' '}
-                    <span className="px-2 bg-gray-300 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
                       [id]
                     </span>
                     ,{' '}
-                    <span className="px-2 bg-gray-300 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
                       [title]
                     </span>
                     ,{' '}
-                    <span className="px-2 bg-gray-300 dark:bg-gray-900 mr-1 inline-block rounded-md">
+                    <span className="px-2 bg-gray-200 dark:bg-gray-900 mr-1 inline-block rounded-md">
                       [url]
                     </span>
                     .
@@ -217,13 +225,20 @@ const Options = ({ manifest }: any) => {
                 <TextArea
                   name="copyToClipboardItemFormat"
                   id="copyToClipboardItemFormat"
-                  className="w-full border-gray-300 rounded shadow-sm dark:text-gray-900 disabled:bg-gray-100 focus:ring-transparent"
+                  className="w-full border-gray-300 rounded shadow-sm dark:text-gray-900 disabled:bg-gray-100 focus:ring-transparent block mb-1"
                   value={inputValue}
                   rows={1}
-                  maxLength={200}
+                  maxLength={CLIPBOARD_ITEM_VALUE_MAX_LENGTH}
                   onChange={handleInputChange(setInputValue)}
                   disabled={submitting}
                 />
+                <p className="mb-0 text-gray-400">
+                  <small>
+                    {`${inputValueRemaining} character${
+                      inputValueRemaining > 1 ? 's' : ''
+                    } left`}
+                  </small>
+                </p>
               </FormGroup>
               <FormGroup>
                 <Button className="mr-4" disabled={submitting}>

--- a/src/pages/Options.tsx
+++ b/src/pages/Options.tsx
@@ -337,7 +337,7 @@ const Options = ({ manifest }: any) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Noel Earvin Piamonte
+                earvinpiamonte.com
               </a>
               .
             </p>

--- a/src/pages/Popup.tsx
+++ b/src/pages/Popup.tsx
@@ -5,8 +5,11 @@ import { CogIcon, ExternalLinkIcon } from '@heroicons/react/solid';
 
 import useTicketWithChrome from '../hooks/useTicketWithChrome';
 
-import { CLIPBOARD_ITEMS_STORAGE_KEY } from '../utils/Constants';
-import { chromeStorageGet, chromeStorageSet } from '../utils/ChromeStorage';
+import {
+  CLIPBOARD_ITEMS_STORAGE_KEY,
+  DEFAULT_CLIPBOARD_ITEM,
+} from '../utils/Constants';
+import { chromeStorageGet } from '../utils/ChromeStorage';
 
 import CopyToClipboardButton from '../components/CopyToClipboardButton';
 
@@ -20,12 +23,7 @@ const Popup = ({ manifest }: any) => {
   const retrieveClipboardItems = async () => {
     const clipboardItems: any = await chromeStorageGet(
       CLIPBOARD_ITEMS_STORAGE_KEY,
-      [
-        {
-          label: 'ID - Title',
-          value: '[id] - [title]',
-        },
-      ]
+      [DEFAULT_CLIPBOARD_ITEM]
     );
 
     const [firstItem] = clipboardItems;

--- a/src/pages/Popup.tsx
+++ b/src/pages/Popup.tsx
@@ -1,21 +1,54 @@
-import React from "react";
+import React from 'react';
 
-import { Helmet } from "react-helmet";
+import { Helmet } from 'react-helmet';
+import { CogIcon, ExternalLinkIcon } from '@heroicons/react/solid';
 
-import { ThemeContext } from "../providers/ThemeProvider";
-import useTicketWithChrome from "../hooks/useTicketWithChrome";
-import CopyToClipboardButton from "../components/CopyToClipboardButton";
+import useTicketWithChrome from '../hooks/useTicketWithChrome';
+
+import { CLIPBOARD_ITEMS_STORAGE_KEY } from '../utils/Constants';
+import { chromeStorageGet, chromeStorageSet } from '../utils/ChromeStorage';
+
+import CopyToClipboardButton from '../components/CopyToClipboardButton';
 
 const Popup = ({ manifest }: any) => {
-  const { nextTheme, setTheme } = React.useContext(ThemeContext);
   const { issueTitle, issueID, issueURL } = useTicketWithChrome();
+  const [customButton, setCustomButton] = React.useState({
+    label: '',
+    value: '',
+  });
+
+  const retrieveClipboardItems = async () => {
+    const clipboardItems: any = await chromeStorageGet(
+      CLIPBOARD_ITEMS_STORAGE_KEY,
+      [
+        {
+          label: 'ID - Title',
+          value: '[id] - [title]',
+        },
+      ]
+    );
+
+    const [firstItem] = clipboardItems;
+    const { label, value } = firstItem;
+
+    let parsedValue = value;
+    parsedValue = parsedValue.replaceAll('[id]', issueID);
+    parsedValue = parsedValue.replaceAll('[title]', issueTitle);
+    parsedValue = parsedValue.replaceAll('[url]', issueURL);
+
+    setCustomButton({ label, value: parsedValue });
+  };
+
+  React.useEffect(() => {
+    retrieveClipboardItems();
+  }, [issueTitle, issueID, issueURL]);
 
   return (
     <>
       <Helmet>
         <title>{manifest?.name}</title>
       </Helmet>
-      <div className="app-popup dark:bg-gray-900 dark:text-gray-300">
+      <div className="app-popup dark:bg-gray-900 dark:text-gray-300 text-base">
         <div className="p-4">
           <div className="mb-4">
             <img
@@ -28,8 +61,8 @@ const Popup = ({ manifest }: any) => {
               {manifest?.name}
             </h1>
           </div>
-          <h2 className="mb-2">
-            <span className="align-middle">Selected issue:</span>{" "}
+          <h2 className="mb-2 text-sm">
+            <span className="align-middle">Selected issue:</span>{' '}
             {issueID && issueURL ? (
               <a
                 href={issueURL}
@@ -37,21 +70,8 @@ const Popup = ({ manifest }: any) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <span className="align-middle text-sm mr-1">{issueID}</span>
-                <svg
-                  className="w-4 h-4 inline-block"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                  />
-                </svg>
+                <span className="align-middle mr-1">{issueID}</span>
+                <ExternalLinkIcon className="w-4 h-4 inline-block" />
               </a>
             ) : (
               <span className="text-gray-500 align-middle">None</span>
@@ -60,30 +80,33 @@ const Popup = ({ manifest }: any) => {
           <div className="mb-4">
             <CopyToClipboardButton
               value={issueID}
-              disabled={!issueID}
               initialText={`Copy ID`}
               endCopyText={`Copied`}
-              className={`block w-full`}
             />
           </div>
           <div className="mb-4">
             <CopyToClipboardButton
               value={issueTitle}
-              disabled={!issueTitle}
               initialText={`Copy title`}
               endCopyText={`Copied`}
-              className={`block w-full`}
             />
           </div>
           <div className="mb-4">
             <CopyToClipboardButton
               value={issueURL}
-              disabled={!issueURL}
               initialText={`Copy link`}
               endCopyText={`Copied`}
-              className={`block w-full`}
             />
           </div>
+          {customButton.label && (
+            <div className="mb-4">
+              <CopyToClipboardButton
+                value={issueID && customButton.value}
+                initialText={`Copy ${customButton.label}`}
+                endCopyText={`Copied`}
+              />
+            </div>
+          )}
         </div>
         <div className="bg-gray-100 border-top py-2 px-4 dark:bg-gray-800 dark:text-gray-300">
           <div className="flex">
@@ -95,40 +118,16 @@ const Popup = ({ manifest }: any) => {
             <div className="flex flex-1 items-center justify-end">
               <button
                 className="py-1 px-2 text-sm text-center rounded-md bg-gray-300 dark:bg-gray-700 dark:text-gray-300 text-sm hover:bg-gray-200 focus:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:hover:bg-gray-600 dark:hover:text-white"
-                onClick={() => setTheme(nextTheme)}
                 aria-label="Toggle dark mode"
+                onClick={() => {
+                  chrome.runtime.openOptionsPage
+                    ? chrome.runtime.openOptionsPage()
+                    : window.open(
+                        chrome.runtime.getURL('index.html?page=Options')
+                      );
+                }}
               >
-                {nextTheme !== "dark" ? (
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-                    />
-                  </svg>
-                ) : (
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-                    />
-                  </svg>
-                )}
+                <CogIcon className="w-4 h-4" />
               </button>
             </div>
           </div>

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "react-helmet";
+import { Helmet } from 'react-helmet';
 
 const Test = () => {
   return (
@@ -6,7 +6,7 @@ const Test = () => {
       <Helmet>
         <title>Test page for popup</title>
       </Helmet>
-      <section className="py-6">
+      <section className="py-6 text-base">
         <div className="md:container md:mx-auto px-4">
           <h1 className="text-2xl mb-4" id="summary-val">
             Lorem ipsum dolor sit amet consectetur adipisicing elit

--- a/src/utils/ChromeStorage.tsx
+++ b/src/utils/ChromeStorage.tsx
@@ -1,0 +1,29 @@
+const chromeStorageGet = async (key: string, defaultValue?: any) => {
+  const promise = new Promise((resolve) => {
+    // chrome.storage.sync.remove(key);
+
+    chrome.storage.sync.get(key, async (result) => {
+      const data = result[key]
+        ? JSON.parse(result[key])
+        : await chromeStorageSet(key, defaultValue);
+
+      resolve(data);
+    });
+  });
+
+  return await promise;
+};
+
+const chromeStorageSet = async (key: string, data: any) => {
+  let obj: any = {};
+  obj[key] = JSON.stringify(data);
+  const parsedData = JSON.parse(obj[key]);
+
+  const promise = new Promise((resolve) => {
+    chrome.storage.sync.set(obj, () => resolve(parsedData));
+  });
+
+  return await promise;
+};
+
+export { chromeStorageGet, chromeStorageSet };

--- a/src/utils/Constants.tsx
+++ b/src/utils/Constants.tsx
@@ -1,3 +1,12 @@
 const CLIPBOARD_ITEMS_STORAGE_KEY = 'clipboardItems';
+const CLIPBOARD_ITEM_VALUE_MAX_LENGTH = 100;
+const DEFAULT_CLIPBOARD_ITEM = {
+  label: 'ID - Title',
+  value: '[id] - [title]',
+};
 
-export { CLIPBOARD_ITEMS_STORAGE_KEY };
+export {
+  CLIPBOARD_ITEMS_STORAGE_KEY,
+  CLIPBOARD_ITEM_VALUE_MAX_LENGTH,
+  DEFAULT_CLIPBOARD_ITEM,
+};

--- a/src/utils/Constants.tsx
+++ b/src/utils/Constants.tsx
@@ -1,0 +1,3 @@
+const CLIPBOARD_ITEMS_STORAGE_KEY = 'clipboardItems';
+
+export { CLIPBOARD_ITEMS_STORAGE_KEY };

--- a/src/utils/Constants.tsx
+++ b/src/utils/Constants.tsx
@@ -1,8 +1,8 @@
 const CLIPBOARD_ITEMS_STORAGE_KEY = 'clipboardItems';
 const CLIPBOARD_ITEM_VALUE_MAX_LENGTH = 100;
 const DEFAULT_CLIPBOARD_ITEM = {
-  label: 'ID - Title',
-  value: '[id] - [title]',
+  label: 'all details',
+  value: '[id] - [title] [url]',
 };
 
 export {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,20 +1,20 @@
 module.exports = {
-  purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
-  darkMode: "class", // or 'media' or 'class'
+  purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
+  darkMode: 'class', // or 'media' or 'class'
   theme: {
     container: {
       // https://github.com/tailwindlabs/tailwindcss/issues/1102#issuecomment-751418459
       screens: {
-        sm: "100%",
-        md: "100%",
-        lg: "640px",
-        xl: "640px",
+        sm: '100%',
+        md: '100%',
+        lg: '640px',
+        xl: '640px',
       },
     },
     extend: {},
   },
   variants: {
-    extend: { opacity: ["disabled"] },
+    extend: { opacity: ['disabled'], backgroundColor: ['disabled'] },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 };


### PR DESCRIPTION
- New custom copy to clipboard button on Popup
- Move extension theme setting on Options page
- Updated Options page to have settings for the custom copy to clipboard button
- Copy to clipboard button value can have `[id]`, `[title]`, `[url]` - which are extracted to the selected issue
- Add modal component
- Installed @tailwindcss/forms
- Installed @heroicons/react

Note:
Support for `[description]` will be on a separate PR.

Resolves #3 .